### PR TITLE
Fix flatpak startup with nvidia drivers

### DIFF
--- a/flatpak/com.github.quaternion.json
+++ b/flatpak/com.github.quaternion.json
@@ -9,7 +9,7 @@
     "command": "quaternion",
     "tags": ["nightly"],
     "desktop-file-name-prefix": "(Nightly) ",
-    "finish-args": ["--share=ipc", "--share=network", "--socket=x11", "--socket=wayland", "--env=QT_QPA_PLATFORM=flatpak"],
+    "finish-args": ["--share=ipc", "--share=network", "--socket=x11", "--socket=wayland", "--env=QT_QPA_PLATFORM=flatpak", "--device=dri"],
 
     "modules": [
         {


### PR DESCRIPTION
We need this argument in order to start the Quaternion flatpak with
nvidia drivers, otherwise we can't create the openGL context.