### PR TITLE
Don't cut the slider in the chat view

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -19,6 +19,8 @@
 
 #include "chatroomwidget.h"
 
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QStyle>
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QLabel>
 
@@ -63,6 +65,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     ctxt->setContextProperty("messageModel", m_messageModel);
     ctxt->setContextProperty("controller", this);
     ctxt->setContextProperty("debug", QVariant(false));
+    ctxt->setContextProperty("applicationStyle", QApplication::style()->objectName());
     m_quickView->setSource(QUrl("qrc:///qml/chat.qml"));
     m_quickView->setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -136,6 +136,10 @@ Item {
         Component.onCompleted: {
             // This will cause continuous scrolling while the scroller is out of 0
             chatView.flickEnded.connect(chatViewScroller.valueChanged)
+            // Fix ugly Slider on Windows.
+            if (applicationStyle === "windows") {
+                width = 10
+            }
         }
     }
 

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -30,6 +30,7 @@ Item {
     ListView {
         id: chatView
         anchors.fill: parent
+        anchors.rightMargin: chatViewScroller.width
 
         model: messageModel
         delegate: messageDelegate
@@ -83,7 +84,7 @@ Item {
             labelPositioning: ViewSection.InlineLabels | ViewSection.CurrentLabelAtStart
 
             delegate: Rectangle {
-                width:parent.width
+                width: root.width
                 height: childrenRect.height
                 color: defaultPalette.window
                 Label { text: section.toLocaleString("dd.MM.yyyy") }
@@ -112,7 +113,7 @@ Item {
     Slider {
         id: chatViewScroller
         orientation: Qt.Vertical
-        anchors.horizontalCenter: chatView.right
+        anchors.left: chatView.right
         anchors.verticalCenter: chatView.verticalCenter
         height: chatView.height / 2
 
@@ -143,7 +144,7 @@ Item {
 
         Rectangle {
             color: defaultPalette.base
-            width: chatView.width
+            width: root.width
             height: childrenRect.height
 
             // A message is considered shown if its bottom is within the
@@ -257,6 +258,10 @@ Item {
                         tooltip: "Show source"
                         checkable: true
                     }
+                }
+                // Spacer for the chatView Slider
+                Item {
+                    width: chatViewScroller.width
                 }
             }
             Rectangle {


### PR DESCRIPTION
This adds a right margin to the chat view so that the Slider doesn't get
cut. We also need to adjust the width of a bunch of other elements to
avoid regressions (such as Slider overlapping the ToolButtons).