### PR TITLE
change "runtime-version" from master to 5.9

### DIFF
--- a/flatpak/com.github.quaternion.json
+++ b/flatpak/com.github.quaternion.json
@@ -4,7 +4,7 @@
     "rename-icon": "quaternion",
     "rename-desktop-file": "quaternion.desktop",
     "runtime": "org.kde.Platform",
-    "runtime-version": "master",
+    "runtime-version": "5.9",
     "sdk": "org.kde.Sdk",
     "command": "quaternion",
     "tags": ["nightly"],


### PR DESCRIPTION
During the Flatpak building it can't find org.kde.Sdk master version, instead version 5.9 is the only available currently. Changing it in the .json file make the Flatpak package build correctly.