### PR TITLE
Inviting and kicking; show rooms in Invite and Left state

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -183,6 +183,11 @@ void ChatRoomWidget::topicChanged()
         m_topicLabel->clear();
 }
 
+QString slashArg(const QString& text, int argNumber = 1)
+{
+    return text.section(' ', argNumber, argNumber, QString::SectionSkipEmpty);
+}
+
 void ChatRoomWidget::sendInput()
 {
     qDebug() << "sendLine";
@@ -193,7 +198,7 @@ void ChatRoomWidget::sendInput()
     // Commands available without current room
     if( text.startsWith("/join") )
     {
-        const QString roomName = text.section(' ', 1, 1, QString::SectionSkipEmpty);
+        const auto roomName = slashArg(text);
         emit joinCommandEntered(roomName);
     }
     else // Commands available only in the room context
@@ -203,6 +208,17 @@ void ChatRoomWidget::sendInput()
             if( text.startsWith("/leave") )
             {
                 m_currentRoom->leaveRoom();
+            }
+            else if( text.startsWith("/invite") )
+            {
+                const auto member = slashArg(text);
+                m_currentRoom->inviteToRoom(member);
+            }
+            else if( text.startsWith("/kick") )
+            {
+                const auto member = slashArg(text);
+                const auto reason = text.section(' ', 2, -1, QString::SectionSkipEmpty);
+                m_currentRoom->kickMember(member, reason);
             }
             else if( text.startsWith("/me") )
             {

--- a/client/models/roomlistmodel.h
+++ b/client/models/roomlistmodel.h
@@ -51,11 +51,15 @@ class RoomListModel: public QAbstractListModel
     private slots:
         void displaynameChanged(QuaternionRoom* room);
         void unreadMessagesChanged(QuaternionRoom* room);
-        void addRoom(QMatrixClient::Room* room);
+        void refresh(QuaternionRoom* room, const QVector<int>& roles = {});
+
+        void updateRoom(QMatrixClient::Room* room,
+                        QMatrixClient::Room* prev);
 
     private:
         QList<Connection*> m_connections;
         QList<QuaternionRoom*> m_rooms;
 
         void doAddRoom(QMatrixClient::Room* r);
+        void connectRoomSignals(QuaternionRoom* room);
 };

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -23,8 +23,10 @@
 
 #include "lib/connection.h"
 
-QuaternionRoom::QuaternionRoom(QMatrixClient::Connection* connection, QString roomId)
-    : QMatrixClient::Room(connection, roomId)
+QuaternionRoom::QuaternionRoom(QMatrixClient::Connection* connection,
+                               QString roomId,
+                               QMatrixClient::JoinState joinState)
+    : QMatrixClient::Room(connection, roomId, joinState)
 {
     m_shown = false;
     m_cachedInput = "";

--- a/client/quaternionroom.h
+++ b/client/quaternionroom.h
@@ -28,7 +28,7 @@ class QuaternionRoom: public QMatrixClient::Room
     public:
         using Timeline = QVector<Message>;
 
-        QuaternionRoom(QMatrixClient::Connection* connection, QString roomId);
+        QuaternionRoom(QMatrixClient::Connection* connection, QString roomId, QMatrixClient::JoinState joinState);
 
         /**
          * set/get whether this room is currently show to the user.

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -107,18 +107,10 @@ void RoomListDock::showContextMenu(const QPoint& pos)
         return;
     auto room = model->roomAt(index.row());
 
-    if( room->joinState() == QMatrixClient::JoinState::Join )
-    {
-        joinAction->setEnabled(false);
-        leaveAction->setEnabled(true);
-        markAsReadAction->setEnabled(true);
-    }
-    else
-    {
-        joinAction->setEnabled(true);
-        leaveAction->setEnabled(false);
-        markAsReadAction->setEnabled(false);
-    }
+    using QMatrixClient::JoinState;
+    joinAction->setEnabled(room->joinState() != JoinState::Join);
+    leaveAction->setEnabled(room->joinState() != JoinState::Leave);
+    markAsReadAction->setEnabled(room->joinState() == JoinState::Join);
 
     contextMenu->popup(mapToGlobal(pos));
 }


### PR DESCRIPTION
This introduces the long-awaited use cases: inviting, kicking, accepting invites and re-joining (if a room is public) a left room. Refers to yet-unmerged PR in libqmatrixclient.
Closes #26 
Closes #157 