### PR TITLE
Introduce AppStream metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ if(LINUX)
     install(FILES linux/quaternion.desktop
             DESTINATION  ${CMAKE_INSTALL_DATADIR}/applications
             )
+    install(FILES linux/com.github.quaternion.appdata.xml
+            DESTINATION  ${CMAKE_INSTALL_DATADIR}/metainfo
+            )
     file(GLOB quaternion_icons icons/quaternion/*-apps-quaternion.png)
     ecm_install_icons(ICONS ${quaternion_icons} icons/quaternion/sc-apps-quaternion.svgz
                       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons

--- a/linux/com.github.quaternion.appdata.xml
+++ b/linux/com.github.quaternion.appdata.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop">
+  <id>com.github.quaternion.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0+</project_license>
+  <name>Quaternion</name>
+  <summary>Matrix Client</summary>
+  <description>
+    <p>
+      Quaternion is a cross-platform desktop IM client for the Matrix protocol.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image width="1300" height="740">https://raw.githubusercontent.com/QMatrixClient/Quaternion/master/quaternion.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/QMatrixClient/Quaternion</url>
+  <provides>
+    <binary>quaternion</binary>
+  </provides>
+</component>


### PR DESCRIPTION
AppStream specification: https://www.freedesktop.org/software/appstream/docs/

The current metadata file is very minimal, but it passes `appstreamcli validate`