### PR TITLE
Added Direct Chat to menu

### DIFF
--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -798,10 +798,8 @@ void MainWindow::directChat(const QString& userId, Connection* connection) {
                                  QMessageBox::Close, QMessageBox::Close);
     }
 
-    using QMatrixClient::BaseJob;
-    auto* user = new QMatrixClient::User(userName, connection);
-    user->requestDirectChat();
-    statusBar()->showMessage(tr("Started chat with %1 as %2")
+    connection->requestDirectChat(userName);
+    statusBar()->showMessage(tr("Starting chat with %1 as %2")
                                 .arg(userId, connection->userId()));
 }
 

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -74,6 +74,8 @@ class MainWindow: public QMainWindow
         void invokeLogin();
         void joinRoom(const QString& roomAlias = {},
                       Connection* connection = nullptr);
+        void directChat(const QString& roomAlias = {},
+                      Connection* connection = nullptr);
         void getNewEvents(Connection* c);
         void gotEvents(Connection* c);
 


### PR DESCRIPTION
Added an option to the menu `Room`>`Direct Chat...` which opens a direct chat room easily with someone who you do not share a room with.

Most of this code was taken from the `joinRoom()` function.