### PR TITLE
CMakeLists.txt: add library as EXCLUDE_FROM_ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(WIN32)
     endif()
 endif()
 
-add_subdirectory(lib)
+add_subdirectory(lib EXCLUDE_FROM_ALL)
 include_directories(lib)
 
 # Get Git info if possible


### PR DESCRIPTION
Prevents the install step from installing qmc-example, libQMatrixClient.a, and the QMatrixClient headers.

I'm assuming that this is unintended, and that installing Quaternion should only install the parts necessary for running the UI. When Quaternion dynamically links to QMatrixClient (https://github.com/QMatrixClient/Quaternion/issues/239) then this will no longer be an issue.

I also don't know what effect this will have on the development environment. The documentation for `add_subdirectory(..., EXCLUDE_FROM_ALL)` says

> If the EXCLUDE_FROM_ALL argument is provided then targets in the subdirectory will not be included in the ALL target of the parent directory by default, and will be excluded from IDE project files.

Which means it might be necessary to configure in this way only when building for packaging and installation.