### PR TITLE
User searching

### DIFF
--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -26,6 +26,7 @@
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QFormLayout>
+#include <QtNetwork/QHostInfo>
 
 #include "settings.h"
 
@@ -87,6 +88,7 @@ LoginDialog::LoginDialog(QWidget* parent)
         else
         {
             saveTokenCheck->setChecked(false);
+            initialDeviceName->setText(QHostInfo::localHostName());
             userEdit->setFocus();
         }
     }

--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -26,7 +26,6 @@
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QFormLayout>
-#include <QtNetwork/QHostInfo>
 
 #include "settings.h"
 
@@ -88,7 +87,6 @@ LoginDialog::LoginDialog(QWidget* parent)
         else
         {
             saveTokenCheck->setChecked(false);
-            initialDeviceName->setText(QHostInfo::localHostName());
             userEdit->setFocus();
         }
     }

--- a/client/models/userlistmodel.cpp
+++ b/client/models/userlistmodel.cpp
@@ -58,13 +58,7 @@ void UserListModel::setRoom(QMatrixClient::Room* room)
         connect( m_currentRoom, &Room::memberAboutToRename, this, &UserListModel::userRemoved );
         connect( m_currentRoom, &Room::memberRenamed, this, &UserListModel::userAdded );
 
-        {
-            QElapsedTimer et; et.start();
-            m_users = m_currentRoom->users();
-            std::sort(m_users.begin(), m_users.end(), room->memberSorter());
-            qDebug() << "Sorting" << m_users.size() << "user(s) in"
-                     << m_currentRoom->displayName() << "took" << et;
-        }
+        filter("");
 
         for( User* user: m_users )
         {
@@ -193,12 +187,4 @@ int UserListModel::findUserPos(User* user) const
 int UserListModel::findUserPos(const QString& username) const
 {
     return m_currentRoom->memberSorter().lowerBoundIndex(m_users, username);
-}
-
-QList<QMatrixClient::User*> UserListModel::sortUsers(QList<QMatrixClient::User*> users) {
-    if ( m_currentRoom == nullptr) {
-        qWarning() << "Cannot sort users without m_currentRoom set";
-        return users;
-    }
-    return users;
 }

--- a/client/models/userlistmodel.h
+++ b/client/models/userlistmodel.h
@@ -42,6 +42,9 @@ class UserListModel: public QAbstractListModel
 
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         int rowCount(const QModelIndex& parent=QModelIndex()) const override;
+    
+    public slots:
+        void filter(QString filterString);
 
     private slots:
         void userAdded(User* user);
@@ -55,4 +58,5 @@ class UserListModel: public QAbstractListModel
 
         int findUserPos(User* user) const;
         int findUserPos(const QString& username) const;
+        QList<User*> sortUsers(QList<User*> users);
 };

--- a/client/models/userlistmodel.h
+++ b/client/models/userlistmodel.h
@@ -58,5 +58,4 @@ class UserListModel: public QAbstractListModel
 
         int findUserPos(User* user) const;
         int findUserPos(const QString& username) const;
-        QList<User*> sortUsers(QList<User*> users);
 };

--- a/client/userlistdock.cpp
+++ b/client/userlistdock.cpp
@@ -22,6 +22,7 @@
 #include <QtWidgets/QTableView>
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QMenu>
+#include <QtWidgets/QLineEdit>
 
 #include <connection.h>
 #include <room.h>
@@ -33,12 +34,25 @@ UserListDock::UserListDock(QWidget* parent)
     , contextMenu(new QMenu(this))
 {
     setObjectName(QStringLiteral("UsersDock"));
-    m_view = new QTableView();
+
+    m_box = new QVBoxLayout();
+
+
+    m_box->addSpacing(1);
+    auto filterline = new QLineEdit(this);
+    filterline->setPlaceholderText(tr("Search"));
+    m_box->addWidget(filterline);
+
+    m_view = new QTableView(this);
     m_view->setShowGrid(false);
     m_view->horizontalHeader()->setStretchLastSection(true);
     m_view->horizontalHeader()->setVisible(false);
     m_view->verticalHeader()->setVisible(false);
-    setWidget(m_view);
+    m_box->addWidget(m_view);
+
+    m_widget = new QWidget(this);
+    m_widget->setLayout(m_box);
+    setWidget(m_widget);
 
     connect(m_view, &QTableView::activated,
             this, &UserListDock::requestUserMention);
@@ -52,6 +66,8 @@ UserListDock::UserListDock(QWidget* parent)
              this, &UserListDock::refreshTitle );
     connect( m_model, &QAbstractListModel::modelReset,
              this, &UserListDock::refreshTitle );
+    connect(filterline, &QLineEdit::textEdited,
+             m_model, &UserListModel::filter);
 
     contextMenu->addAction(QIcon::fromTheme("contact-new"),
         tr("Open direct chat"), this, &UserListDock::startChatSelected);

--- a/client/userlistdock.cpp
+++ b/client/userlistdock.cpp
@@ -37,7 +37,6 @@ UserListDock::UserListDock(QWidget* parent)
 
     m_box = new QVBoxLayout();
 
-
     m_box->addSpacing(1);
     auto filterline = new QLineEdit(this);
     filterline->setPlaceholderText(tr("Search"));

--- a/client/userlistdock.h
+++ b/client/userlistdock.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QDockWidget>
 
 namespace QMatrixClient
@@ -49,6 +50,8 @@ class UserListDock: public QDockWidget
         void requestUserMention();
 
     private:
+        QWidget* m_widget;
+        QVBoxLayout* m_box;
         QTableView* m_view;
         UserListModel* m_model;
 


### PR DESCRIPTION
This adds a search bar to the users docker that allows you to search/filter users in the room easily.
Works quite well and is very fast even though it's just linear (tested in #matrix:matrix.org).

Also I minor QoL of setting the device name to the machine's hostname when there are no accounts to pull that info from.