### PR TITLE
Set inital device name to hostname

### DIFF
--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -26,6 +26,7 @@
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QFormLayout>
+#include <QtNetwork/QHostInfo>
 
 #include "settings.h"
 
@@ -87,6 +88,7 @@ LoginDialog::LoginDialog(QWidget* parent)
         else
         {
             saveTokenCheck->setChecked(false);
+            initialDeviceName->setText(QHostInfo::localHostName());
             userEdit->setFocus();
         }
     }


### PR DESCRIPTION
When adding an account when there are none set it to the device name.