### PR TITLE
Set a few more macOS info.plist items

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,11 +152,18 @@ if(WIN32)
 endif()
 
 if(APPLE)
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.github.quaternion")
+    set(MACOSX_BUNDLE_BUNDLE_NAME "quaternion")
+
+    set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2018 QMatrixClient Project")
+
+    set(VERSION "0.0.9.4")
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${VERSION})
+    set(MACOSX_BUNDLE_BUNDLE_VERSION ${VERSION})
+
     set(ICON_NAME "quaternion.icns")
     set(ICON_PATH "${CMAKE_CURRENT_SOURCE_DIR}/icons/${ICON_NAME}")
-
     set(MACOSX_BUNDLE_ICON_FILE ${ICON_NAME})
-
     set_source_files_properties("${ICON_PATH}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endif(APPLE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 project(quaternion CXX)
 
+set(VERSION "0.0.9.4")
+
 if(UNIX AND NOT APPLE)
     set(LINUX 1)
 endif(UNIX AND NOT APPLE)
@@ -157,7 +159,6 @@ if(APPLE)
 
     set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2018 QMatrixClient Project")
 
-    set(VERSION "0.0.9.4")
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${VERSION})
     set(MACOSX_BUNDLE_BUNDLE_VERSION ${VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 project(quaternion CXX)
 
 set(VERSION "0.0.9.4")
+set(COPYRIGHT "Copyright © 2018 QMatrixClient Project")
 
 if(UNIX AND NOT APPLE)
     set(LINUX 1)
@@ -157,7 +158,7 @@ if(APPLE)
     set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.github.quaternion")
     set(MACOSX_BUNDLE_BUNDLE_NAME "quaternion")
 
-    set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2018 QMatrixClient Project")
+    set(MACOSX_BUNDLE_COPYRIGHT ${COPYRIGHT})
 
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${VERSION})
     set(MACOSX_BUNDLE_BUNDLE_VERSION ${VERSION})

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -6,24 +6,18 @@
 	<string>English</string>
 	<key>CFBundleExecutable</key>
 	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
-	<key>CFBundleGetInfoString</key>
-	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
 	<key>CFBundleIconFile</key>
 	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
 	<key>CFBundleIdentifier</key>
 	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleLongVersionString</key>
-	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>CFBundleName</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>CSResourcesFileMapped</key>


### PR DESCRIPTION
Fixes #462 

I used the same identifier as the linux packages `com.github.quaternion`. If there is a better thing to set that to, let me know.

I'm just setting CFBundleVersion and CFShortVersionString to the same thing, and I guess I'll just set the version manually. I wasn't sure if there was a way for cmake to "know" what the version is automatically.

Get Info screen looks like this after the PR:
![screen shot 2018-12-27 at 12 42 18 am](https://user-images.githubusercontent.com/5855073/50469009-4a5b5f00-0970-11e9-97fd-a47aee88d24c.png)
