### PR TITLE
AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,21 @@ before_install:
 
 script:
 - mkdir build && cd build
-- cmake .. -DUSE_INTREE_LIBQMC=1 # TODO: add building with an external lib
+- if [ "$TRAVIS_OS_NAME" != "linux" ]; then cmake .. -DUSE_INTREE_LIBQMC=1; fi # TODO: add building with an external lib
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then  cmake .. -DUSE_INTREE_LIBQMC=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr; fi
 - cmake --build . --target all
 #- appstream-util validate linux/*.appdata.xml
+- |
+  if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "clang" ]; then
+    make DESTDIR=appdir -j$(nproc) install ; find appdir/
+    wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+    chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+    unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+    export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+    ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+    wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+    bash upload.sh Quaternion*.AppImage*
+  fi
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,16 @@ before_install:
 script:
 - mkdir build && cd build
 - cmake .. -DUSE_INTREE_LIBQMC=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX # TODO: add building with an external lib
-- cmake --build . --target all
 #- appstream-util validate linux/*.appdata.xml
+- cmake --build . --target all
+- DESTDIR=install cmake --build . --target install && find install/
 - |
   if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "clang" ]; then
-    make DESTDIR=appdir -j$(nproc) install ; find appdir/
     wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
     chmod a+x linuxdeployqt-continuous-x86_64.AppImage
-    unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+    unset QTDIR QT_PLUGIN_PATH LD_LIBRARY_PATH
     export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
-    ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+    ./linuxdeployqt-continuous-x86_64.AppImage install/usr/share/applications/*.desktop -appimage
     wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
     bash upload.sh Quaternion*.AppImage*
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     env: [ 'ENV_EVAL="CC=gcc-5 && CXX=g++-5"' ]
   - os: linux
     compiler: clang
+    env: [ 'ENV_EVAL="INSTALL_PREFIX=/usr"' ]
   - os: osx
     env: [ 'PATH=/usr/local/opt/qt/bin:$PATH"' ]
 
@@ -30,8 +31,7 @@ before_install:
 
 script:
 - mkdir build && cd build
-- if [ "$TRAVIS_OS_NAME" != "linux" ]; then cmake .. -DUSE_INTREE_LIBQMC=1; fi # TODO: add building with an external lib
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then  cmake .. -DUSE_INTREE_LIBQMC=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr; fi
+- cmake .. -DUSE_INTREE_LIBQMC=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX # TODO: add building with an external lib
 - cmake --build . --target all
 #- appstream-util validate linux/*.appdata.xml
 - |


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.