### PR TITLE
Deploy .dmg files for each build to Bintray

### DIFF
--- a/.ci/bintray-release.json
+++ b/.ci/bintray-release.json
@@ -1,0 +1,25 @@
+{
+  "files": [
+    {
+      "includePattern": "build/quaternion.dmg",
+      "uploadPattern": "quaternion-VERSION_VALUE.dmg"
+    }
+  ],
+  "package": {
+    "desc": "A Qt5-based IM client for the Matrix protocol",
+    "issue_tracker_url": "https://github.com/QMatrixClient/Quaternion",
+    "licenses": [
+      "GPL-3.0"
+    ],
+    "name": "Quaternion",
+    "subject": "BINTRAY_USER",
+    "repo": "Quaternion",
+    "public_download_numbers": true,
+    "public_stats": true,
+    "vcs_url": "https://github.com/QMatrixClient/Quaternion"
+  },
+  "version": {
+    "name": "VERSION_VALUE"
+  },
+  "publish": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 
+git:
+  depth: false
+
 before_cache:
   - brew cleanup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: cpp
 
+before_cache:
+  - brew cleanup
+
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ deploy:
   user: $BINTRAY_USER
   key: $BINTRAY_TOKEN
   skip_cleanup: true
-  on:
-    all_branches: true
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
 
 before_deploy:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then macdeployqt quaternion.app -dmg; fi
+- cd ..
 - sed -i -e "s/VERSION_VALUE/$(git rev-list --count HEAD)/g" .ci/bintray-release.json
 - sed -i -e "s/BINTRAY_USER/$BINTRAY_USER/g" .ci/bintray-release.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ deploy:
   user: $BINTRAY_USER
   key: $BINTRAY_TOKEN
   skip_cleanup: true
+  on:
+    all_branches: true
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,18 @@ script:
 - cmake --build . --target all
 #- appstream-util validate linux/*.appdata.xml
 
+before_deploy:
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then macdeployqt quaternion.app -dmg; fi
+- sed -i -e "s/VERSION_VALUE/$(git rev-list --count HEAD)/g" .ci/bintray-release.json
+- sed -i -e "s/BINTRAY_USER/$BINTRAY_USER/g" .ci/bintray-release.json
+
+deploy:
+- provider: bintray
+  file: .ci/bintray-release.json
+  user: $BINTRAY_USER
+  key: $BINTRAY_TOKEN
+  skip_cleanup: true
+
 notifications:
   webhooks:
     urls:

--- a/README.md
+++ b/README.md
@@ -39,12 +39,8 @@ Flatpaks for Quaternion are available from Flathub. To install, use `flatpak ins
 
 #### macOS
 You can download the latest release from [GitHub](https://github.com/QMatrixClient/Quaternion/releases/latest).
-Make sure you have Qt5 installed; if you don't have it, call this in Terminal:
-`brew install qt5`.
 
 Alternatively, you can install Quaternion from [Homebrew Cask](https://brew.sh)
-(in this case Qt5 is downloaded and installed automatically if needed):
-
 ```
 brew cask install quaternion
 ```


### PR DESCRIPTION
Fixes #449
This works for now and it shouldn't be to hard to automate GitHub Releases for tags from this.

Also fixes #466, was wondering why my .app was so much smaller :) than the windows build. Using macdeployqt will include qt with the .app so users don't have to install qt. I'll send @KitsuneRal a 0.0.9.3 .dmg once this PR is approved.