### PR TITLE
call activateWindow() in addition to raise()/setFocus()

### DIFF
--- a/client/systemtrayicon.cpp
+++ b/client/systemtrayicon.cpp
@@ -80,6 +80,7 @@ void SystemTrayIcon::showHide()
     else
     {
         m_parent->show();
+        m_parent->activateWindow();
         m_parent->raise();
         m_parent->setFocus();
     }


### PR DESCRIPTION
for me (X11) rise() does not bring the window in front of all other windows in all cases, activateWindow() does