### PR TITLE
Change user highlight to use RegEx

### DIFF
--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -21,7 +21,7 @@
 
 #include <user.h>
 #include <events/roommessageevent.h>
-#include <QRegularExpression>
+#include <QtCore/QRegularExpression>
 
 using namespace QMatrixClient;
 

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -21,6 +21,7 @@
 
 #include <user.h>
 #include <events/roommessageevent.h>
+#include <QRegularExpression>
 
 using namespace QMatrixClient;
 
@@ -104,9 +105,13 @@ void QuaternionRoom::checkForHighlights(const QMatrixClient::TimelineItem& ti)
         return;
     if (auto* e = ti.viewAs<RoomMessageEvent>())
     {
+        const QRegularExpression localUserRe("(\\W|^)" + localUserId + "(\\W|$)", QRegularExpression::MultilineOption | QRegularExpression::CaseInsensitiveOption);
+        const QRegularExpression roomMembernameRe("(\\W|^)" + roomMembername(localUserId) + "(\\W|$)", QRegularExpression::MultilineOption | QRegularExpression::CaseInsensitiveOption);
         const auto& text = e->plainBody();
-        if (text.contains(localUserId) ||
-                text.contains(roomMembername(localUserId)))
+        QRegularExpressionMatch localMatch = localUserRe.match(text, 0, QRegularExpression::PartialPreferFirstMatch);
+        QRegularExpressionMatch roomMemberMatch = roomMembernameRe.match(text, 0, QRegularExpression::PartialPreferFirstMatch);
+        if (localMatch.hasMatch() ||
+                roomMemberMatch.hasMatch())
             highlights.insert(e);
     }
 }


### PR DESCRIPTION
User highlighting is now based on Regular Expression instead of simple 'contains.'  This should help prevent errors in highlighting when it shouldn't be done.

Here's a picture showing that it still works :)

![image](https://user-images.githubusercontent.com/962117/52517538-bfc27c80-2c0a-11e9-85a5-79b800b66efc.png)
