### PR TITLE
Fix hide mainwindow

### DIFF
--- a/client/activitydetector.cpp
+++ b/client/activitydetector.cpp
@@ -1,6 +1,6 @@
 /**************************************************************************
  *                                                                        *
- * Copyright (C) 2016 Malte Brandy <malte.brandy@maralorn.de>                        *
+ * Copyright (C) 2016 Malte Brandy <malte.brandy@maralorn.de>             *
  *                                                                        *
  * This program is free software; you can redistribute it and/or          *
  * modify it under the terms of the GNU General Public License            *

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -109,6 +109,10 @@ int main( int argc, char* argv[] )
         qDebug() << "--- Show time!";
         window.show();
     }
+    else {
+      qDebug() << "--- Hide time!";
+      window.hide();
+    }
 
     return app.exec();
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -105,13 +105,13 @@ int main( int argc, char* argv[] )
     }
 
     ActivityDetector ad(app, window); Q_UNUSED(ad);
-    if (!parser.isSet(hideMainWindow)) {
-        qDebug() << "--- Show time!";
-        window.show();
+    if (parser.isSet(hideMainWindow)) {
+        qDebug() << "--- Hide time!";
+        window.hide();
     }
     else {
-      qDebug() << "--- Hide time!";
-      window.hide();
+        qDebug() << "--- Show time!";
+        window.show();
     }
 
     return app.exec();


### PR DESCRIPTION
--hide-mainwindow option did not work for me because the main window had been arising somewhere besides main(). Calling window.hide() on start is not a beautiful  solution, but it is guarantee to hide even if window was shown somewhere wile constructing.