### PR TITLE
Attachment: fix openExternally()

### DIFF
--- a/client/qml/Attachment.qml
+++ b/client/qml/Attachment.qml
@@ -16,7 +16,7 @@ Item {
 
     function openExternally()
     {
-        if (progressInfo.localPath || downloaded)
+        if (progressInfo.localPath.toString() || downloaded)
             openLocalFile()
         else
         {


### PR DESCRIPTION
The if condition was always true. Converting `progressInfo.localPath` to a string
should fix it.