### PR TITLE
Use colour-coding for user disambiguation

### DIFF
--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -47,6 +47,7 @@ enum EventRoles {
     SpecialMarksRole,
     LongOperationRole,
     AnnotationRole,
+    UserHueRole,
     // For debugging
     EventResolvedTypeRole,
 };
@@ -68,6 +69,7 @@ QHash<int, QByteArray> MessageEventModel::roleNames() const
     roles[SpecialMarksRole] = "marks";
     roles[LongOperationRole] = "progressInfo";
     roles[AnnotationRole] = "annotation";
+    roles[UserHueRole] = "userHue";
     roles[EventResolvedTypeRole] = "eventResolvedType";
     return roles;
 }
@@ -725,6 +727,11 @@ QVariant MessageEventModel::data(const QModelIndex& idx, int role) const
                 return data(i, role == AboveSectionRole
                                 ? SectionRole : AuthorRole);
         }
+
+    if (role == UserHueRole)
+        return QVariant::fromValue(isPending
+                                   ? m_currentRoom->localUser()->hueF()
+                                   : m_currentRoom->user(evt.senderId())->hueF());
 
     return {};
 }

--- a/client/models/userlistmodel.cpp
+++ b/client/models/userlistmodel.cpp
@@ -22,6 +22,8 @@
 #include <QElapsedTimer>
 #include <QtCore/QDebug>
 #include <QtGui/QPixmap>
+#include <QtGui/QPalette>
+#include <QtWidgets/QApplication>
 
 #include <connection.h>
 #include <room.h>
@@ -106,6 +108,16 @@ QVariant UserListModel::data(const QModelIndex& index, int role) const
         if (!user->bridged().isEmpty())
             tooltip += "<br>" + tr("Bridged from: %1").arg(user->bridged());
         return tooltip;
+    }
+
+    if (role == Qt::ForegroundRole)
+    {
+        // FIXME: boilerplate with TimelineItem.qml:57
+        return QColor::fromHslF(user->hueF(),
+                                1 - QApplication::palette().color(QPalette::Window).saturationF(),
+                                -0.7 * QApplication::palette().color(QPalette::Window).lightnessF() + 0.9,
+                                QApplication::palette().color(QPalette::ButtonText).alphaF()
+                                );
     }
 
     return QVariant();

--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -54,27 +54,12 @@ Item {
         (["state", "notice", "other"].indexOf(eventType) >= 0) ?
                 disabledPalette.text : defaultPalette.text
     readonly property string authorName: room && room.roomMembername(author.id)
-    function stringToHue(str) {
-        var hash = 0
-        if ((str).length === 0)
-            return hash
-        for (var i = 0; i < (str).length; i++) {
-            hash = (str).charCodeAt(i) + ((hash << 5) - hash)
-            hash = hash & hash
-        }
-        return Math.abs(hash)/2147483647
-    }
-    function stringToColor(str) {
-        if (str) {
-            return Qt.hsla(stringToHue(str),
-                           (1-defaultPalette.window.hslSaturation),
-                           /* contrast but not too heavy: */
-                           (-0.6*defaultPalette.window.hslLightness + 0.9),
-                           textColor.a)
-        }
-        return textColor
-    }
-    readonly property color fancyColor: stringToColor(authorName)
+    // FIXME: boilerplate with models/userlistmodel.cpp:115
+    readonly property string authorColor: Qt.hsla(userHue,
+                                                  (1-defaultPalette.window.hslSaturation),
+                                                  /* contrast but not too heavy: */
+                                                  (-0.7*defaultPalette.window.hslLightness + 0.9),
+                                                  defaultPalette.buttonText.a)
 
     readonly property bool xchatStyle: settings.timeline_style === "xchat"
     readonly property bool actionEvent: eventType == "state" || eventType == "emote"
@@ -169,7 +154,7 @@ Item {
                     actionEvent ? Text.AlignRight : Text.AlignLeft
                 elide: Text.ElideRight
 
-                color: fancyColor
+                color: authorColor
                 textFormat: Label.PlainText
                 font.bold: !xchatStyle
                 renderType: settings.render_type
@@ -268,9 +253,9 @@ Item {
                     textFormat: TextEdit.RichText
                     // FIXME: The text is clumsy and slows down creation
                     text: (actionEvent && !xchatStyle ?
-                           ("<a href='#mention' style='text-decoration:none;color:\"" +
-                                    fancyColor + "\"'><b>" +
-                                    authorName + "</b></a> ") : ""
+                           ("<a href='" + author.id + "' style='text-decoration:none;color:\"" +
+                                    authorColor + "\"'><b>" +
+                                    toHtmlEscaped(authorName) + "</b></a> ") : ""
                           ) + display +
                           (annotation ? "<br><em>" + annotation + "</em>" : "")
                     horizontalAlignment: Text.AlignLeft

--- a/client/qml/TimelineItem.qml
+++ b/client/qml/TimelineItem.qml
@@ -53,7 +53,28 @@ Item {
         highlight && settings.highlight_mode == "text" ? settings.highlight_color :
         (["state", "notice", "other"].indexOf(eventType) >= 0) ?
                 disabledPalette.text : defaultPalette.text
-    readonly property string authorName: room && room.safeMemberName(author.id)
+    readonly property string authorName: room && room.roomMembername(author.id)
+    function stringToHue(str) {
+        var hash = 0
+        if ((str).length === 0)
+            return hash
+        for (var i = 0; i < (str).length; i++) {
+            hash = (str).charCodeAt(i) + ((hash << 5) - hash)
+            hash = hash & hash
+        }
+        return Math.abs(hash)/2147483647
+    }
+    function stringToColor(str) {
+        if (str) {
+            return Qt.hsla(stringToHue(str),
+                           (1-defaultPalette.window.hslSaturation),
+                           /* contrast but not too heavy: */
+                           (-0.6*defaultPalette.window.hslLightness + 0.9),
+                           textColor.a)
+        }
+        return textColor
+    }
+    readonly property color fancyColor: stringToColor(authorName)
 
     readonly property bool xchatStyle: settings.timeline_style === "xchat"
     readonly property bool actionEvent: eventType == "state" || eventType == "emote"
@@ -148,7 +169,7 @@ Item {
                     actionEvent ? Text.AlignRight : Text.AlignLeft
                 elide: Text.ElideRight
 
-                color: textColor
+                color: fancyColor
                 textFormat: Label.PlainText
                 font.bold: !xchatStyle
                 renderType: settings.render_type
@@ -247,9 +268,9 @@ Item {
                     textFormat: TextEdit.RichText
                     // FIXME: The text is clumsy and slows down creation
                     text: (actionEvent && !xchatStyle ?
-                           ("<a href='" + author.id + "' style='text-decoration:none;color:\"" +
-                                    defaultPalette.text + "\"'><b>" +
-                                    toHtmlEscaped(authorName) + "</b></a> ") : ""
+                           ("<a href='#mention' style='text-decoration:none;color:\"" +
+                                    fancyColor + "\"'><b>" +
+                                    authorName + "</b></a> ") : ""
                           ) + display +
                           (annotation ? "<br><em>" + annotation + "</em>" : "")
                     horizontalAlignment: Text.AlignLeft


### PR DESCRIPTION
Contributes to issue #513 
I like this HSL-based appoarch so tried to help (implemented similar for r0kk3rz Sailfish OS version), but feel to reject/correct :)

Checked with different KDE color schemes:

![Imgur](https://i.imgur.com/DXb8UL7.png)